### PR TITLE
Resolve #1, add support for newer Dockerfile syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ Each match group and result has to be implemented manually.
 * EXPOSE
 * ENTRYPOINT
 * VOLUME
-* ARG
 * ONBUILD
 * STOPSIGNAL
 * HEALTHCHECK
@@ -51,15 +50,25 @@ Translate these instructions manually:
 * USER - execute the next block(s) with `su` or equivalent
 * SHELL - unwrap JSON-formatted arguments, run it for subsequent block(s)
 
+Additionally, any pure comment lines (starting with `#`) are removed during conversion in order to support multi-line RUN statements with embedded comments, which is standard Dockerfile practise.
+
 ### ENV
 
 Before:
 
     ENV FOO bar
+    ENV FOO=bar
+    ENV FOO
 
 After:
 
     export FOO=bar
+    export FOO=bar
+    # (no value assigned) ENV FOO
+
+### ARG
+
+Same as ENV
 
 ### RUN
 
@@ -138,6 +147,8 @@ After:
 ## Copyright
 
 Copyright 2018, Development Gateway
+
+Copyright 2022, Dennis Schneidermann - modifications stated in source
 
 This program is free software: you can redistribute it and/or modify it under the terms of
 the GNU General Public License as published by the Free Software Foundation, either version 3 of

--- a/README.md
+++ b/README.md
@@ -2,6 +2,34 @@
 
 This script naively translates some Dockerfile instructions into corresponding shell commands.
 
+## Usage
+
+The file to use is `dkr2sh.sed`, which is a sed script, note how it starts:
+```
+#!/bin/sed -f
+# Convert Dockerfile to shell script.
+```
+
+To use it, normal sed usage implies it takes stdin and outputs stdout. So:
+```
+./dkr2sh.sed < Dockerfile > mydockerscript.sh
+```
+
+## Contributing
+The explanation of the tranform rules below matches with .sh files, eg. `copy-from.sh`, `copy.sh` and `add.sh`
+
+In the `dkr2sh.sed` file, the transform rules have been translated to sed patterns. The `sh2sed.sh` is the helper script that can do this as part of manual labour. You can change any of the patterns and run, eg. `./sh2sed.sh < copy-from.sh` and you will get this:
+```
+for i in ARGS; do\n\ttest -d "$i" \&\& i="$i\/"\n\trsync -a "$i" DEST # FROM\ndone
+```
+
+It matches the replacement string in the `dkr2sh.sed` file, here, but with match groups inserted inplace of ARGS, DEST, FROM
+```
+s/^[[:space:]]*COPY\([[:space:]]\+--from=[^[:space:]]\+\)\(\([[:space:]]\+[^[:space:]]\+\)\+\)\([[:space:]]\+[^[:space:]]\+\)[[:space:]]*/for i in\2; do\n\ttest -d "$i" \&\& i="$i\/"\n\trsync -a "$i"\4 #\1\ndone/i
+```
+
+Each match group and result has to be implemented manually.
+
 ## Conversion Rules
 
 ### Instructions commented out

--- a/dkr2sh.sed
+++ b/dkr2sh.sed
@@ -1,12 +1,22 @@
 #!/bin/sed -f
 # Convert Dockerfile to shell script.
 # Copyright 2018, Development Gateway, GPLv3+
+# Copyright 2022, Dennis Schneidermann, GPLv3+ - modifications noted by "dss"
+
+# remove pure comment lines to support multi-line RUN statements - added by dss 20220223
+/^[[:space:]]*#.*/d;
 
 # comment out other instructions
-/^[[:space:]]*\<\(FROM\|CMD\|LABEL\|MAINTAINER\|EXPOSE\|ENTRYPOINT\|VOLUME\|USER\|ARG\|ONBUILD\|STOPSIGNAL\|HEALTHCHECK\|SHELL\)\>/I s/^[[:space:]]*/# /;
+/^[[:space:]]*\<\(FROM\|CMD\|LABEL\|MAINTAINER\|EXPOSE\|ENTRYPOINT\|VOLUME\|USER\|ONBUILD\|STOPSIGNAL\|HEALTHCHECK\|SHELL\)\>/I s/^[[:space:]]*/# /;
 
-# ENV instructions become export commands
-s/^[[:space:]]*ENV[[:space:]]\+\([^[:space:]]\+\)[[:space:]]\+\(.\+\)/export \1='\2'/i;
+# ENV and ARG instructions become export commands - modified to support ARG by dss 20220223
+s/^[[:space:]]*\(ENV\|ARG\)[[:space:]]\+\([^[:space:]]\+\)[[:space:]]\+\(.\+\)/export \2=\3/i;
+
+# ENV and ARG instructions become export commands (alternate) - added by dss 20220223
+s/^[[:space:]]*\(ENV\|ARG\)[[:space:]]\+\([^[:space:]]\+\)=\(.\+\)/export \2=\3/i;
+
+# comment out any unparsable ENV or ARG instructions - added by dss 20220223
+/^[[:space:]]*\<\(ENV\|ARG\)\>/I s/^[[:space:]]*/# (no value assigned) /;
 
 # RUN get executed literally, including line wraps
 s/^[[:space:]]*RUN[[:space:]]\+//i;


### PR DESCRIPTION
Add usage and contributing instructions. Closes #1 

Add pre-processing to remove pure comment lines from the Dockerfile input, which makes multi-line RUN statements work, such as:
```
RUN apt-get update \
   # Install packages foo and bar
   apt-get install foo bar
```

Add ARG syntax that matches the ENV behavior, to support using buildargs with defaults.

Update ENV and ARG to support the equals syntax (ENV FOO=...) and change the output so it doesn't quote strings with `'`, as it is a significant difference from Dockerfile behavior. Eg. this is now possible:
```
ARG USERNAME=foo
ENV HOME=/home/$USERNAME
```
